### PR TITLE
Fix for secondary issues relating to issue #61

### DIFF
--- a/lib/mix/tasks/server.ex
+++ b/lib/mix/tasks/server.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Server do
     end
 
     opts = add_config(opts)
-    router = Sugar.Config.get(:placid, :router, Router)
+    router = Sugar.Config.get(:sugar, :router, Router)
     router.run
 
     # TODO: is there a better way than `Code.ensure_loaded?(Mix.Tasks.ServerTest)`?


### PR DESCRIPTION
Fixes a mismatch of the router module name between an application and Sugar's `Mix.Tasks.Server`.  See comments for issue #61 for more details on the exact symptoms being addressed.