### PR TITLE
Fix Sugar.Router

### DIFF
--- a/lib/sugar/router.ex
+++ b/lib/sugar/router.ex
@@ -8,7 +8,8 @@ defmodule Sugar.Router do
                    Sugar.Request.Parsers.XML,
                    :urlencoded,
                    :multipart ]
-    end
+			@before_compile Sugar.Router
+		end
   end
 
   @doc false


### PR DESCRIPTION
Should no longer choke on `run` when running `mix server`.  This fixes Issue #65.