### PR TITLE
Fixing parentheses

### DIFF
--- a/lib/sugar/controller.ex
+++ b/lib/sugar/controller.ex
@@ -83,9 +83,9 @@ defmodule Sugar.Controller do
       end
 
       def call(conn, opts) do
-        conn = do_call conn, :before, opts[:action]
-        conn = apply __MODULE__, opts[:action], [ conn, opts[:args] ]
-        do_call conn, :after, opts[:action]
+        conn = do_call(conn, :before, opts[:action])
+        conn = apply(__MODULE__, opts[:action], [ conn, opts[:args] ])
+        do_call(conn, :after, opts[:action])
       end
 
       defoverridable [init: 1, call: 2]
@@ -98,7 +98,7 @@ defmodule Sugar.Controller do
     only_actions = get_only_actions plugs
 
     Enum.map only_actions ++ [nil], fn action ->
-      build_plug_stacks_for action, plugs
+      build_plug_stacks_for(action, plugs)
     end
   end
 

--- a/lib/sugar/controller/helpers.ex
+++ b/lib/sugar/controller/helpers.ex
@@ -25,19 +25,19 @@ defmodule Sugar.Controller.Helpers do
         use Sugar.Controller
 
         def index(conn, []) do
-          render conn, "showing index controller"
+          render(conn, "showing index controller")
         end
 
         def show(conn, args) do
-          render conn, "showing page \#{args[:id]}"
+          render(conn, "showing page \#{args[:id]}")
         end
 
         def create(conn, []) do
-          render conn, "page created"
+          render(conn, "page created")
         end
 
         def get_json(conn, []) do
-          json conn, [message: "foobar"]
+          json(conn, [message: "foobar"])
         end
       end
   """
@@ -96,7 +96,7 @@ defmodule Sugar.Controller.Helpers do
   @spec static(Plug.Conn.t, binary) :: Plug.Conn.t
   def static(conn, file) do
     filename = Path.join(["priv/static", file])
-    if File.exists? filename do
+    if File.exists?(filename) do
       body = filename |> File.read!
       conn
         |> put_resp_content_type_if_not_sent("text/html")
@@ -209,7 +209,7 @@ defmodule Sugar.Controller.Helpers do
   """
   @spec halt!(Plug.Conn.t, Keyword.t) :: Plug.Conn.t
   def halt!(conn, opts \\ []) do
-    opts = [status: 401, message: ""] |> Keyword.merge opts
+    opts = [status: 401, message: ""] |> Keyword.merge(opts)
     conn
       |> send_resp_if_not_sent(opts[:status], opts[:message])
   end
@@ -247,7 +247,7 @@ defmodule Sugar.Controller.Helpers do
   """
   @spec forward(Plug.Conn.t, atom, atom, Keyword.t) :: Plug.Conn.t
   def forward(conn, controller, action, args \\ []) do
-    apply controller, action, [conn, args]
+    apply(controller, action, [conn, args])
   end
 
   @doc """
@@ -265,7 +265,7 @@ defmodule Sugar.Controller.Helpers do
   """
   @spec redirect(Plug.Conn.t, binary, Keyword.t) :: Plug.Conn.t
   def redirect(conn, location, opts \\ []) do
-    opts = [status: 302] |> Keyword.merge opts
+    opts = [status: 302] |> Keyword.merge(opts)
     conn
       |> put_resp_header_if_not_sent("Location", location)
       |> send_resp_if_not_sent(opts[:status], "")

--- a/lib/sugar/router.ex
+++ b/lib/sugar/router.ex
@@ -34,14 +34,14 @@ defmodule Sugar.Router do
         end
 
         if is_list(opts[:https]) and opts[:https] != [] do
-          adapter.https __MODULE__, [], opts[:https]
+          adapter.https(__MODULE__, [], opts[:https])
         end
 
         if opts[:https_only] == true do
           # Sends `403 Forbidden` to all HTTP requests
-          adapter.http Sugar.Request.HttpsOnly, [], opts[:http]
+          adapter.http(Sugar.Request.HttpsOnly, [], opts[:http])
         else
-          adapter.http __MODULE__, [], opts[:http]
+          adapter.http(__MODULE__, [], opts[:http])
         end
       end
     end

--- a/lib/sugar/supervisor.ex
+++ b/lib/sugar/supervisor.ex
@@ -18,7 +18,7 @@ defmodule Sugar.Supervisor do
   """
   def init(opts) do
     children = []
-    opts = Keyword.put opts, :strategy, :one_for_one
+    opts = Keyword.put(opts, :strategy, :one_for_one)
 
     supervise(children, opts)
   end


### PR DESCRIPTION
Half of the code contains parentheses around functions' arguments, and it's a bit disturbing to constantly switch from a syntax to another. It shouldn't break anything. 