### PR TITLE
Implement a HTTP→HTTPS redirect option for `:https_only`

### DIFF
--- a/lib/sugar/request/http_to_https.ex
+++ b/lib/sugar/request/http_to_https.ex
@@ -1,0 +1,22 @@
+defmodule Sugar.Request.HttpToHttps do
+  @moduledoc false
+
+  @spec init(Keyword.t) :: Keyword.t
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t, Keyword.t) :: Plug.Conn.t
+  def call(conn, opts \\ []) do
+    # WARNING: this does the minimum necessary to get HTTP->HTTPS
+    # redirection working (without having to basically reimplement
+    # Plug.SSL) with custom HTTPS ports.  Those with more advanced use
+    # cases should consider unsetting Sugar's :https_only option and
+    # sticking Plug.SSL into their router directly instead (which
+    # complicates things for Sugar's HTTPS config, but is
+    # hypothetically possible and would enable the use of HSTS and
+    # "x-forwarded-proto" headers.
+    port = opts[:port] || 8443
+    opts = [ host: conn.host <> ":#{port}",
+             hsts: false ]
+    conn |> Plug.SSL.call(Plug.SSL.init(opts))
+  end
+end

--- a/lib/sugar/router.ex
+++ b/lib/sugar/router.ex
@@ -42,7 +42,7 @@ defmodule Sugar.Router do
           # be configured to use a different handler or plug by
           # setting the :https_only_handler option
           Keyword.get(opts, :https_only_handler, Sugar.Request.HttpsOnly)
-            |> adapter.http([], opts[:http])
+            |> adapter.http([port: opts[:https][:port]], opts[:http])
         else
           adapter.http(__MODULE__, [], opts[:http])
         end

--- a/lib/sugar/router.ex
+++ b/lib/sugar/router.ex
@@ -38,8 +38,11 @@ defmodule Sugar.Router do
         end
 
         if opts[:https_only] == true do
-          # Sends `403 Forbidden` to all HTTP requests
-          adapter.http(Sugar.Request.HttpsOnly, [], opts[:http])
+          # Sends `403 Forbidden` to all HTTP requests by default; can
+          # be configured to use a different handler or plug by
+          # setting the :https_only_handler option
+          Keyword.get(opts, :https_only_handler, Sugar.Request.HttpsOnly)
+            |> adapter.http([], opts[:http])
         else
           adapter.http(__MODULE__, [], opts[:http])
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sugar.Mixfile do
   def project do
     [ app: :sugar,
       elixir: "~> 1.0",
-      version: "0.4.10",
+      version: "0.4.11",
       name: "Sugar",
       source_url: "https://github.com/sugar-framework/sugar",
       homepage_url: "https://sugar-framework.github.io",


### PR DESCRIPTION
To summarize:

* A new `:https_only_handler` configuration option has been added.  It's expected to be set to a module name.  If not set, Sugar still defaults to `Sugar.Request.HttpsOnly` (thus preserving the current behavior of throwing a `Forbidden` at non-HTTPS requests)
* A new `Sugar.Request.HttpToHttps` handler has been implemented.  It wraps `Plug.SSL`.
* A version bump (since this is worthwhile for a new version, right?).

Pinging @slogsdon and/or @Annwenn for a review / sanity check before this gets merged in.