### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://img.shields.io/travis/sugar-framework/sugar.svg?style=flat)](https://travis-ci.org/sugar-framework/sugar)
 [![Coverage Status](https://img.shields.io/coveralls/sugar-framework/sugar.svg?style=flat)](https://coveralls.io/r/sugar-framework/sugar)
 [![Hex.pm Version](http://img.shields.io/hexpm/v/sugar.svg?style=flat)](https://hex.pm/packages/sugar)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/sugar-framework/sugar.svg)](https://beta.hexfaktor.org/github/sugar-framework/sugar)
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/sugar-framework/sugar?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Modular web framework for Elixir


### PR DESCRIPTION
Hi there,

we don't know each other, but I'd like to propose this badge (based on my latest project for the Elixir community):

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/sugar-framework/sugar.svg)](https://beta.hexfaktor.org/github/sugar-framework/sugar)

The badge shows you an analysis for your Hex dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think!
