### PR TITLE
Add guide in terminal

### DIFF
--- a/lib/mix/tasks/server.ex
+++ b/lib/mix/tasks/server.ex
@@ -18,12 +18,9 @@ defmodule Mix.Tasks.Server do
     Mix.Task.run "app.start", args
     Mix.Task.run "compile.sugar", args
 
-    if Keyword.has_key? opts, :port do
-      opts = Keyword.update!(opts, :port, &binary_to_integer(&1))
-      Mix.shell.info "== Sugar running in http://127.0.0.1:#{opts[:port]} =="
-    else
-      Mix.shell.info "== Sugar running in http://127.0.0.1:4000 =="
-    end
+    opts = opts |> Keyword.update(:port, 4000, &binary_to_integer(&1))
+    
+    Mix.shell.info "== Sugar running in http://127.0.0.1:#{opts[:port]} =="
 
     opts = add_config opts
     router = Sugar.Config.get(:sugar, :router, Router)

--- a/lib/mix/tasks/server.ex
+++ b/lib/mix/tasks/server.ex
@@ -20,6 +20,9 @@ defmodule Mix.Tasks.Server do
 
     if Keyword.has_key? opts, :port do
       opts = Keyword.update!(opts, :port, &binary_to_integer(&1))
+      Mix.shell.info "== Sugar running in http://127.0.0.1:#{opts[:port]} =="
+    else
+      Mix.shell.info "== Sugar running in http://127.0.0.1:4000 =="
     end
 
     opts = add_config opts


### PR DESCRIPTION
I added some guide about localhost port number in terminal. It would be a little help. I'm not sure that this is the right position to put in 'Mix.shell.info', so please review and update if there is any problem.
Or, if you know a better form than 'Sugar running in ...', don't hesitate to fix on this commit.